### PR TITLE
update readme: GPU credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,4 +134,4 @@ and won't be registered with or pushed to GitHub.
 
 ## Training On GPU
 
-Coming soon.  We still need to get our AWS credits for this part.
+This section coming soon.


### PR DESCRIPTION
Fixed some wording in the Readme about not having AWS credits yet.